### PR TITLE
fixed: WRAP_CONTENT & Gallery.LayoutParams vs. other LayoutParams...

### DIFF
--- a/library/src/at/technikum/mti/fancycoverflow/FancyCoverFlowAdapter.java
+++ b/library/src/at/technikum/mti/fancycoverflow/FancyCoverFlowAdapter.java
@@ -20,6 +20,7 @@ package at.technikum.mti.fancycoverflow;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.BaseAdapter;
+import android.widget.LinearLayout.LayoutParams;
 
 
 public abstract class FancyCoverFlowAdapter extends BaseAdapter {
@@ -59,7 +60,8 @@ public abstract class FancyCoverFlowAdapter extends BaseAdapter {
 
 
         coverFlowItem.addView(wrappedView);
-        coverFlowItem.setLayoutParams(wrappedView.getLayoutParams());
+		//we will fix the layoutParam incompatibility here
+        coverFlowItem.setLayoutParams(new FancyCoverFlow.LayoutParams(wrappedView.getLayoutParams()));
 
         return coverFlowItem;
     }

--- a/library/src/at/technikum/mti/fancycoverflow/FancyCoverFlowItemWrapper.java
+++ b/library/src/at/technikum/mti/fancycoverflow/FancyCoverFlowItemWrapper.java
@@ -17,16 +17,23 @@
 
 package at.technikum.mti.fancycoverflow;
 
-import android.*;
-import android.R;
 import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.content.Context;
-import android.graphics.*;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.ColorMatrix;
+import android.graphics.ColorMatrixColorFilter;
+import android.graphics.LinearGradient;
+import android.graphics.Matrix;
+import android.graphics.Paint;
+import android.graphics.PorterDuff;
+import android.graphics.PorterDuffXfermode;
+import android.graphics.Shader;
 import android.os.Build;
 import android.util.AttributeSet;
 import android.view.View;
-import android.view.ViewGroup;
+import android.widget.LinearLayout;
 
 /**
  * This class has only internal use (package scope).
@@ -41,7 +48,7 @@ import android.view.ViewGroup;
  * children or not (there can only be one at all times).
  */
 @SuppressWarnings("ConstantConditions")
-class FancyCoverFlowItemWrapper extends ViewGroup {
+class FancyCoverFlowItemWrapper extends LinearLayout {
 
     // =============================================================================
     // Private members


### PR DESCRIPTION
fixed: WRAP_CONTENT will now work for child groups -> onMeasure inheritance over LinearLayout instead of ViewGroup->View

fixed: due to creation of new Gallery.LayoutParams from the wrappedView params we are save in supporting the superset from ViewGroup.LayoutParams
