### PR TITLE
coverflow image stacking/overlap improvement

### DIFF
--- a/library/src/at/technikum/mti/fancycoverflow/FancyCoverFlow.java
+++ b/library/src/at/technikum/mti/fancycoverflow/FancyCoverFlow.java
@@ -361,6 +361,25 @@ public class FancyCoverFlow extends Gallery {
         return true;
     }
 
+    @Override
+    protected int getChildDrawingOrder(int childCount, int i) {
+        int selectedIndex = getSelectedItemPosition() - getFirstVisiblePosition();
+
+        // Just to be safe
+        if (selectedIndex < 0) return i;
+
+        if (i == childCount - 1) {
+            // Draw the selected child last
+            return selectedIndex;
+        } else if (i >= selectedIndex) {
+            // Move the children after the selected child so as to stack them, order increasing as we approach selected child
+            return getLastVisiblePosition() - getFirstVisiblePosition() - (i - selectedIndex);
+        } else {
+            // Keep the children before the selected child the same
+            return i;
+        }
+    }
+
     // =============================================================================
     // Public classes
     // =============================================================================


### PR DESCRIPTION
Please see screenshots. 

Problem: The items in the coverflow were incorrectly stacking (to the right of the selected item) and was an eyesore when overlapping.

Solution: Override the gallery getChildDrawingOrder 
The solution has been tested, see the 'improvement' screenshot (NB the images to the right of the selected item are now correctly stacked)

![coverflow improvment](https://cloud.githubusercontent.com/assets/7987374/4441842/db6afa1e-47d7-11e4-8f7d-0ec1068eabf8.png)
![coverflow before](https://cloud.githubusercontent.com/assets/7987374/4441843/df17a95a-47d7-11e4-81a8-c0100f30e61c.png)
